### PR TITLE
Enable to build anyone

### DIFF
--- a/core/build.gradle
+++ b/core/build.gradle
@@ -4,21 +4,13 @@ apply from: '../gradle-mvn-push.gradle'
 targetCompatibility = '1.6'
 sourceCompatibility = '1.6'
 
-def Properties props = new Properties()
-props.load(new FileInputStream(file('../local.properties')))
-
-ext.android = [
-		sdk   : props["sdk.dir"],
-		target: 'android-21'
-]
-
 repositories {
 	mavenCentral()
 }
 
 dependencies {
-	compile files("${android.sdk}/platforms/${android.target}/android.jar")
-	compile files("${android.sdk}/extras/android/support/v4/android-support-v4.jar")
+	compile 'com.google.android:android:4.1.1.4'
+	compile 'com.google.android:support-v4:r7'
 	compile 'io.reactivex:rxjava:1.0.2'
 
 	testCompile project(':compiler')

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Thu Dec 11 09:57:34 EST 2014
+#Fri Feb 20 04:59:53 JST 2015
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-2.2.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-2.2.1-all.zip


### PR DESCRIPTION
Hi, I tried to compile in local environment but it failed.
The reason is `core/build.gradle` had a reference to `local.properties`.
So I changed android framework dependency's repository to maven central.
The previous android.jar's version is 'android-21', but I think it is not necessary until when needed.