### PR TITLE
Replacement of "compile" with "implementation"

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ Grab via Maven:
 ```
 or Gradle:
 ```groovy
-compile 'com.michaelpardo:ollie:0.3.1'
+implementation 'com.michaelpardo:ollie:0.3.1'
 provided 'com.michaelpardo:ollie-compiler:0.3.1'
 ```
 


### PR DESCRIPTION
As "compile" is going to be deprecated end-2018, this PR replaces with "implementation" that is the new usage.